### PR TITLE
Fix double `c:\` on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,7 @@ impl zed::Extension for DockerfileExtension {
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
-                env::current_dir()
-                    .unwrap()
+                zed_ext::sanitize_windows_path(env::current_dir().unwrap())
                     .join(&server_path)
                     .to_string_lossy()
                     .to_string(),
@@ -83,3 +82,24 @@ impl zed::Extension for DockerfileExtension {
 }
 
 zed::register_extension!(DockerfileExtension);
+
+mod zed_ext {
+    /// Sanitizes the given path to remove the leading `/` on Windows.
+    ///
+    /// On macOS and Linux this is a no-op.
+    ///
+    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
+    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
+        use zed_extension_api::{current_platform, Os};
+
+        let (os, _arch) = current_platform();
+        match os {
+            Os::Mac | Os::Linux => path,
+            Os::Windows => path
+                .to_string_lossy()
+                .to_string()
+                .trim_start_matches('/')
+                .into(),
+        }
+    }
+}


### PR DESCRIPTION
- Closes: https://github.com/zed-extensions/dockerfile/issues/14
- Supersedes: https://github.com/zed-extensions/dockerfile/pull/15

CC: @vipexv