### PR TITLE
Add injection for comment extension

### DIFF
--- a/languages/dockerfile/injections.scm
+++ b/languages/dockerfile/injections.scm
@@ -1,6 +1,5 @@
-; We need impl this
-; ((comment) @injection.content
-;  (#set! injection.language "comment"))
+((comment) @content
+ (#set! injection.language "comment"))
 
 ((shell_command) @content
  (#set! "language" "bash"))


### PR DESCRIPTION
This will be supported by the comment extension. If the extension is not installed, then this would be a no-op.