### PR TITLE
Bump version to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "zed_dockerfile"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_dockerfile"
-version = "0.0.6"
+version = "0.1.0"
 edition = "2021"
 publish = false
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "dockerfile"
 name = "Dockerfile"
 description = "Dockerfile support."
-version = "0.0.6"
+version = "0.1.0"
 schema_version = 1
 authors = ["d1y <chenhonzho@gmail.com>", "joshmeads <github@joshmeads.com>"]
 repository = "https://github.com/zed-extensions/dockerfile"


### PR DESCRIPTION
This PR bumps the version of the extension to 0.1.0.

Includes: 
- https://github.com/zed-extensions/dockerfile/pull/25
- https://github.com/zed-extensions/dockerfile/pull/27