### PR TITLE
Use local LSP binary if available

### DIFF
--- a/src/language_servers/dockerfile_language_server_nodejs.rs
+++ b/src/language_servers/dockerfile_language_server_nodejs.rs
@@ -51,6 +51,19 @@ impl DockerfileLs {
             });
         }
 
+        if let Some(path) = worktree.which("docker-langserver") {
+            let args = binary_settings
+                .as_ref()
+                .and_then(|s| s.arguments.clone())
+                .unwrap_or_else(|| vec!["--stdio".to_string()]);
+
+            return Ok(zed::Command {
+                command: path,
+                args,
+                env,
+            });
+        }
+
         let server_path = self.server_script_path(language_server_id)?;
 
         let default_args = vec![


### PR DESCRIPTION
Closes https://github.com/zed-extensions/dockerfile/issues/20

I was annoyed by Zed downloading a bunch of things and this extension was one of the culprits 🙂 

Following the [pattern in the other file](https://github.com/zed-extensions/dockerfile/blob/main/src/language_servers/docker_language_server.rs), this enables the local binary to be used if available (say if the user installed it with `brew install dockerfile-language-server` or `npm install -g dockerfile-language-server-nodejs`). If not, the LSP is downloaded as before.

This change was not tested as I am unsure how to do that and the change seems straightforward 😅 I am happy to test it if y'all want me to!