### PR TITLE
Add Docker Compose language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Compose files are given their own `Docker Compose` language, matched on
 `compose.yaml`, `compose.yml`, `docker-compose.yaml` and `docker-compose.yml`.
 Plain YAML files are unaffected.
 
-Each entry under `services:` gets a runnable, so a single service can be started
-from the gutter. `docker compose`, `docker-compose`, `podman compose` and
-`podman-compose` are all offered.
+Each entry under `services:` gets a runnable, so a single service can be run from
+the gutter via `compose run` — which starts a one-off container for that service
+rather than bringing the service up. `docker compose`, `docker-compose`,
+`podman compose` and `podman-compose` are all offered.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,17 @@ Compose files are given their own `Docker Compose` language, matched on
 `compose.yaml`, `compose.yml`, `docker-compose.yaml` and `docker-compose.yml`.
 Plain YAML files are unaffected.
 
-Each entry under `services:` gets a runnable, so a single service can be run from
-the gutter via `compose run` — which starts a one-off container for that service
-rather than bringing the service up. `docker compose`, `docker-compose`,
-`podman compose` and `podman-compose` are all offered.
+Each entry under `services:` gets runnables, so a single service can be brought
+up, run and taken down from the gutter:
+
+| Task | Effect |
+| --- | --- |
+| `up` | starts the service and its dependencies, attached so logs appear in the terminal |
+| `run` | starts a one-off container for the service |
+| `down` | stops and removes the service's containers |
+
+Each is offered for `docker compose`, `docker-compose`, `podman compose` and
+`podman-compose`.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # Dockerfile Zed Extension
 
-- Tree Sitter: [tree-sitter-dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile)
-- Language Server: [dockerfile-language-server](https://github.com/rcjsuen/dockerfile-language-server)
+- Tree Sitter: [tree-sitter-dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile), [tree-sitter-yaml](https://github.com/zed-industries/tree-sitter-yaml)
+- Language Server: [dockerfile-language-server](https://github.com/rcjsuen/dockerfile-language-server), [docker-language-server](https://github.com/docker/docker-language-server)
+
+## Docker Compose
+
+Compose files are given their own `Docker Compose` language, matched on
+`compose.yaml`, `compose.yml`, `docker-compose.yaml` and `docker-compose.yml`.
+Plain YAML files are unaffected.
+
+Each entry under `services:` gets a runnable, so a single service can be started
+from the gutter. `docker compose`, `docker-compose`, `podman compose` and
+`podman-compose` are all offered.
 
 ## Configuration
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "dockerfile"
 name = "Dockerfile"
-description = "Dockerfile support."
+description = "Dockerfile and Docker Compose support."
 version = "0.2.1"
 schema_version = 1
 authors = ["d1y <chenhonzho@gmail.com>", "joshmeads <github@joshmeads.com>"]
@@ -17,11 +17,17 @@ languages = ["Dockerfile", "Docker Compose"]
 
 [language_servers.docker-language-server.language_ids]
 "Dockerfile" = "dockerfile"
-"Docker Compose" = "docker-compose"
+"Docker Compose" = "dockercompose"
 
 [grammars.dockerfile]
 repository = "https://github.com/camdencheek/tree-sitter-dockerfile"
 commit = "868e44ce378deb68aac902a9db68ff82d2299dd0"
+
+# Registered as `yaml` rather than `docker-compose` so the id is snake_case and
+# matches the `tree_sitter_yaml` symbol the parser exports.
+[grammars.yaml]
+repository = "https://github.com/zed-industries/tree-sitter-yaml"
+commit = "baff0b51c64ef6a1fb1f8390f3ad6015b83ec13a"
 
 [debug_adapters.buildx-dockerfile]
 schema_path = "./debug_adapter_schemas/buildx-dockerfile.json"

--- a/languages/docker-compose/brackets.scm
+++ b/languages/docker-compose/brackets.scm
@@ -1,0 +1,3 @@
+("[" @open "]" @close)
+("{" @open "}" @close)
+("\"" @open "\"" @close)

--- a/languages/docker-compose/brackets.scm
+++ b/languages/docker-compose/brackets.scm
@@ -1,3 +1,13 @@
-("[" @open "]" @close)
-("{" @open "}" @close)
-("\"" @open "\"" @close)
+("[" @open
+  "]" @close)
+
+("{" @open
+  "}" @close)
+
+(("\"" @open
+  "\"" @close)
+  (#set! rainbow.exclude))
+
+(("'" @open
+  "'" @close)
+  (#set! rainbow.exclude))

--- a/languages/docker-compose/config.toml
+++ b/languages/docker-compose/config.toml
@@ -1,0 +1,27 @@
+# Adjusted from https://github.com/zed-industries/zed/blob/f2ab00cec7545ffb7d8d75e4ccab74d5fccccf9b/crates/languages/src/yaml/config.toml
+name = "Docker Compose"
+grammar = "yaml"
+path_suffixes = [
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "compose.yaml",
+    "compose.yml",
+]
+line_comments = ["# "]
+autoclose_before = ",]}"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = [
+        "string",
+    ] },
+    { start = "'", end = "'", close = true, newline = false, not_in = [
+        "string",
+    ] },
+]
+
+auto_indent_on_paste = false
+auto_indent_using_last_non_empty_line = false
+increase_indent_pattern = ":\\s*[|>]?\\s*$"
+prettier_parser_name = "yaml"
+tab_size = 2

--- a/languages/docker-compose/config.toml
+++ b/languages/docker-compose/config.toml
@@ -1,4 +1,5 @@
-# Adjusted from https://github.com/zed-industries/zed/blob/f2ab00cec7545ffb7d8d75e4ccab74d5fccccf9b/crates/languages/src/yaml/config.toml
+# Adjusted from Zed's own YAML config, crates/grammars/src/yaml/config.toml,
+# since this language shares the grammar Zed uses for YAML.
 name = "Docker Compose"
 grammar = "yaml"
 path_suffixes = [
@@ -22,6 +23,8 @@ brackets = [
 
 auto_indent_on_paste = false
 auto_indent_using_last_non_empty_line = false
-increase_indent_pattern = ":\\s*[|>]?\\s*$"
+# 1st block matches basic elements followed by ':', e.g. 'test: '
+# 2nd block matches the first element of an array when it's an object
+increase_indent_pattern = "(:?^[^#]*:\\s*[|>]?\\s*$)|(:?^\\s*-[^#]*:\\s*(:?#+.*)$)"
 prettier_parser_name = "yaml"
 tab_size = 2

--- a/languages/docker-compose/highlights.scm
+++ b/languages/docker-compose/highlights.scm
@@ -1,0 +1,51 @@
+; Taken from https://github.com/zed-industries/zed/blob/f2ab00cec7545ffb7d8d75e4ccab74d5fccccf9b/crates/languages/src/yaml/highlights.scm
+; as the "Docker Compose" language shares the grammar zed uses for YAML
+(boolean_scalar) @boolean
+(null_scalar) @constant.builtin
+
+[
+  (double_quote_scalar)
+  (single_quote_scalar)
+  (block_scalar)
+  (string_scalar)
+] @string
+
+(escape_sequence) @string.escape
+
+[
+  (integer_scalar)
+  (float_scalar)
+] @number
+
+(comment) @comment
+
+[
+  (anchor_name)
+  (alias_name)
+  (tag)
+] @type
+
+key: (flow_node (plain_scalar (string_scalar) @property))
+
+[
+  ","
+  "-"
+  ":"
+  ">"
+  "?"
+  "|"
+] @punctuation.delimiter
+
+[
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  "*"
+  "&"
+  "---"
+  "..."
+] @punctuation.special

--- a/languages/docker-compose/outline.scm
+++ b/languages/docker-compose/outline.scm
@@ -1,0 +1,1 @@
+(block_mapping_pair key: (flow_node (plain_scalar (string_scalar) @name))) @item

--- a/languages/docker-compose/outline.scm
+++ b/languages/docker-compose/outline.scm
@@ -1,1 +1,7 @@
-(block_mapping_pair key: (flow_node (plain_scalar (string_scalar) @name))) @item
+(block_mapping_pair
+  key: (flow_node
+    (plain_scalar
+      (string_scalar) @name))
+  value: (flow_node
+    (plain_scalar
+      (string_scalar) @context))?) @item

--- a/languages/docker-compose/overrides.scm
+++ b/languages/docker-compose/overrides.scm
@@ -1,0 +1,6 @@
+(comment) @comment.inclusive
+
+[
+  (single_quote_scalar)
+  (double_quote_scalar)
+] @string

--- a/languages/docker-compose/redactions.scm
+++ b/languages/docker-compose/redactions.scm
@@ -1,0 +1,1 @@
+(block_mapping_pair value: (flow_node) @redact)

--- a/languages/docker-compose/redactions.scm
+++ b/languages/docker-compose/redactions.scm
@@ -1,1 +1,2 @@
-(block_mapping_pair value: (flow_node) @redact)
+(block_mapping_pair
+  value: (flow_node) @redact)

--- a/languages/docker-compose/runnables.scm
+++ b/languages/docker-compose/runnables.scm
@@ -1,0 +1,6 @@
+(document (block_node (block_mapping (block_mapping_pair
+    key: _ @_services
+    value: (block_node (block_mapping (block_mapping_pair
+            key: _ @service @run)))
+    (#eq? @_services "services")
+    (#set! tag docker-compose-service)))))

--- a/languages/docker-compose/tasks.json
+++ b/languages/docker-compose/tasks.json
@@ -1,0 +1,22 @@
+[
+  {
+    "label": "docker-compose run",
+    "command": "docker-compose -f $ZED_FILE run $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
+    "label": "docker compose run",
+    "command": "docker compose -f $ZED_FILE run $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
+    "label": "podman-compose run",
+    "command": "podman-compose -f $ZED_FILE run $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
+    "label": "podman compose run",
+    "command": "podman compose -f $ZED_FILE run $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  }
+]

--- a/languages/docker-compose/tasks.json
+++ b/languages/docker-compose/tasks.json
@@ -1,7 +1,22 @@
 [
   {
+    "label": "docker-compose up",
+    "command": "docker-compose -f $ZED_FILE up $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
     "label": "docker-compose run",
     "command": "docker-compose -f $ZED_FILE run $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
+    "label": "docker-compose down",
+    "command": "docker-compose -f $ZED_FILE down $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
+    "label": "docker compose up",
+    "command": "docker compose -f $ZED_FILE up $ZED_CUSTOM_service",
     "tags": ["docker-compose-service"]
   },
   {
@@ -10,13 +25,38 @@
     "tags": ["docker-compose-service"]
   },
   {
+    "label": "docker compose down",
+    "command": "docker compose -f $ZED_FILE down $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
+    "label": "podman-compose up",
+    "command": "podman-compose -f $ZED_FILE up $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
     "label": "podman-compose run",
     "command": "podman-compose -f $ZED_FILE run $ZED_CUSTOM_service",
     "tags": ["docker-compose-service"]
   },
   {
+    "label": "podman-compose down",
+    "command": "podman-compose -f $ZED_FILE down $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
+    "label": "podman compose up",
+    "command": "podman compose -f $ZED_FILE up $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
     "label": "podman compose run",
     "command": "podman compose -f $ZED_FILE run $ZED_CUSTOM_service",
+    "tags": ["docker-compose-service"]
+  },
+  {
+    "label": "podman compose down",
+    "command": "podman compose -f $ZED_FILE down $ZED_CUSTOM_service",
     "tags": ["docker-compose-service"]
   }
 ]


### PR DESCRIPTION
Moves Docker Compose support in from
[eth0net/zed-docker-compose](https://github.com/eth0net/zed-docker-compose), per
the discussion on zed-industries/extensions#7105. Thanks @MrSubidubi — you were
right that shipping the language server twice was the wrong shape.

## What's here

**A `Docker Compose` language**, matched on `compose.yaml`, `compose.yml`,
`docker-compose.yaml` and `docker-compose.yml`. Its own language rather than an
extension of YAML, which is what keeps the server off plain YAML files — the
original extension attached to YAML wholesale and that caused unresolved-tag
warnings and `MULTIPLE_DOCS` errors on unrelated files
(eth0net/zed-docker-compose#2, zed-industries/zed#12122).

**Runnables for services.** Each entry under `services:` can be started from the
gutter, offering `docker compose`, `docker-compose`, `podman compose` and
`podman-compose`. This is @lnay's work from the original extension.

**A fix to the language id.** The existing `language_ids` mapping sent
`docker-compose`, but the server gates every Compose feature on
`dockercompose`:

```go
DockerComposeLanguage LanguageIdentifier = "dockercompose"
```

So Compose features would have been silently dead. It had no effect before now
because nothing defined the language for the mapping to apply to.

The grammar is registered as `yaml`, not `docker-compose` — ids must be
snake_case *and* match the symbol the parser exports, which for tree-sitter-yaml
is `tree_sitter_yaml`. Registering under any other name fails to link:

```
wasm-ld: error: symbol exported via --export not found: tree_sitter_docker_compose
```

Highlight queries are copied from Zed's YAML queries rather than shared, since
queries can't be delegated between languages.

## Verification

Driven against docker-language-server v0.20.1 over stdio with the exact
`initializationOptions` the extension sends:

| languageId | Result |
| --- | --- |
| `dockercompose` | hover with compose-spec schema docs, symbols, completion, rename |
| `docker-compose` | nothing |
| `yaml` | nothing |

The grammar was compiled with Zed's bundled wasi-sdk clang both ways to confirm
the symbol constraint above. `cargo build --release --target wasm32-wasip2`
passes.

## Notes

- **No version bump** — I left that to `extensions::bump_version`. This probably
  wants the `minor` label.
- zed-industries/extensions#7105 should be closed rather than merged if this
  lands, otherwise both extensions would define a `Docker Compose` language and
  collide. Happy to close it myself once you've had a look.
- That leaves the standalone `docker-compose` extension redundant. It's still
  published at 0.1.0, which predates the language definition, so there's no
  collision in the meantime. I'm glad to retire it — let me know what you'd
  prefer for existing users.

## Not yet covered

The server also handles Bake files (HCL), which nothing here exposes. Out of
scope for this PR, but worth noting as the remaining gap.
